### PR TITLE
Prepend ',' to setup_dramatiq when it's imported.

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/app.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/app.py
@@ -5,7 +5,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from .extensions import (
     babel, toolbar, sentry, oauth_user, db, migrate, redis_store, csrf_protect
-{% if cookiecutter.use_async_task == "yes" %}    setup_dramatiq{% endif %}
+{% if cookiecutter.use_async_task == "yes" %}    ,setup_dramatiq{% endif %}
 )
 from .globals import register_globals
 from .settings import Config


### PR DESCRIPTION
## Description of the change
Prepended "," when the `setup_dramatiq` is being conditionally imported.
> Description here

Refer to the issue linked.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix [Syntax error when creating a new project with async_task](https://github.com/fulfilio/cookiecutter-fulfil/issues/9)

## Checklists

### Code review
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
